### PR TITLE
Initialise lastPasteboardChangeCount

### DIFF
--- a/DragMonitor/DragMonitorApp.swift
+++ b/DragMonitor/DragMonitorApp.swift
@@ -23,7 +23,7 @@ struct DragMonitorApp: App {
 class AppDelegate: NSObject, NSApplicationDelegate {
 
   var dragMonitor: Any?
-  var lastPasteboardChangeCount: Int = 0
+  var lastPasteboardChangeCount: Int = NSPasteboard(name: .drag).changeCount
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     dragMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDragged) { _ in


### PR DESCRIPTION
If the first event after application starts is a non-file drag event, it will incorrectly trigger the code. This code fixes it